### PR TITLE
fix: code-block style and adjust color matching (close #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 [README](README.md) | [CHANGELOG](CHANGELOG.md)
 
+## 1.1.1
+
+- adjust color matching
+- fix the `code-group` and `code-block` styles on vuepress 1.6.0
+
 ## 1.1.0
 
 - remove `css-prefers-color-scheme`
 - refactor `defaultTheme`
 
 ```
+defaultTheme: null -> <html>
 defaultTheme: 'light' -> <html theme="light">
 defaultTheme: 'dark' -> <html theme="dark">
 ```

--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ npm i vuepress-theme-default-prefers-color-scheme
 ``` js
 // .vuepress -> config.js
 module.exports = {
-  theme: 'default-prefers-color-scheme',
-  themeConfig: {
-    // ...
-  }
+  theme: 'default-prefers-color-scheme'
 }
 ```
 
@@ -36,7 +33,7 @@ module.exports = {
 - Type: `string`, `object`
 - Required: `false`
 
-By default, light or dark themes are displayed by [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme). You can break it by set `defaultTheme`.
+**By default, light or dark themes are displayed by [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme). You can break it by set `defaultTheme`.**
 
 support `light`, `dark` or `{ theme: [begin hours, end hours] }`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-default-prefers-color-scheme",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "description": "add prefers-color-scheme for vuepress default theme",
   "author": "tolking <qw13131wang@gmail.com>",

--- a/styles/components.styl
+++ b/styles/components.styl
@@ -61,6 +61,7 @@
 
 .dropdown-wrapper
   .dropdown-title
+  .mobile-dropdown-title
     color var(--textColor)
 
   .nav-dropdown
@@ -145,7 +146,14 @@
 .page-edit .last-updated .prefix
   color var(--lighten25TextColor)
 
+.page-edit .last-updated .time
+  color var(--lighten40TextColor)
+
 // sidebar
+.sidebar .nav-links
+.page-nav .inner
+  border-color var(--borderColor)
+
 .sidebar-heading
   color var(--textColor)
 

--- a/styles/index.styl
+++ b/styles/index.styl
@@ -161,7 +161,6 @@ body
 
 .navbar
 h2
-.sidebar .nav-links
   border-bottom-color var(--borderColor)
 
 .sidebar
@@ -183,8 +182,7 @@ p a code
   color var(--accentColor)
 
 hr
-.page-nav .inner
-  border-top-color var(--borderColor) !important
+  border-top-color var(--borderColor)
 
 tr
   border-top-color var(--tableBorderColor)
@@ -215,6 +213,9 @@ border-left-color var(--arrowBgColor)
   .token.inserted
     color var(--accentColor)
 
+  .token.punctuation
+    color var(--preTextColor)
+
 {$contentClass} pre
 
 {$contentClass} pre[class*='language-']
@@ -241,6 +242,18 @@ div[class*='language-']::before
 
 div[class*='language-'].line-numbers-mode .line-numbers-wrapper
   color var(--lineNumbersColor)
+
+.theme-code-block > pre
+  background-color var(--codeBgColor) !important
+
+.theme-code-group .theme-code-group__nav
+  background-color var(--codeBgColor) !important
+
+  .theme-code-group__nav-tab
+    color var(--textColor) !important
+
+  .theme-code-group__nav-tab-active
+    border-color: var(--accentColor) !important
 
 // custom-block
 .custom-block.tip

--- a/styles/palette.styl
+++ b/styles/palette.styl
@@ -25,7 +25,7 @@ $badgeErrorColor ?= #DA5961
 $badgeErrorDarkColor ?= $badgeErrorColor
 
 $preTextColor ?= #fff
-$preTextLightColor ?= #525252
+$preTextLightColor ?= #4d4d4d
 
 $highlightedBgColor ?= rgba(0, 0, 0, .66)
 $highlightedBgLightColor ?= rgba(224, 224, 224, 0.5)
@@ -73,7 +73,7 @@ $dangerColor ?= #c00
 $dangerDarkColor ?= $dangerColor
 
 $dangerBgColor ?= #ffe6e6
-$dangerBgDarkColor ?= rgba(255, 214, 214, 0.3)
+$dangerBgDarkColor ?= rgba(72, 56, 57, 30%)
 
 $searchBorderColor ?= #999
 $searchBorderDarkColor ?= #eee


### PR DESCRIPTION
- adjust color matching
- fix the `code-group` and `code-block` styles on vuepress 1.6.0